### PR TITLE
add JSON write examples

### DIFF
--- a/src/main/resources/record_3.0/samples/write_samples/address-3.0.json
+++ b/src/main/resources/record_3.0/samples/write_samples/address-3.0.json
@@ -1,0 +1,5 @@
+{
+  "country": {
+    "value": "CA"
+  }
+}

--- a/src/main/resources/record_3.0/samples/write_samples/bulk-works-100-works-3.0.json
+++ b/src/main/resources/record_3.0/samples/write_samples/bulk-works-100-works-3.0.json
@@ -1,0 +1,4775 @@
+{
+  "bulk": [
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 1"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": {
+          "citation-type": "bibtex",
+          "citation-value": "\n\t\t\t@article {ORCID2012,\n\t\t\t\ttitle = \"ORCID: a system to uniquely identify researchers\",\n\t\t\t\tjournal = \"Learned Publishing\",\n\t\t\t\tyear = \"2022\",\n\t\t\t\tdoi = \"doi:10.1087/20140404\"\n\t\t\t\t}\n\t\t"
+        },
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2021"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1001/j.crvasa.2015.05.007",
+              "external-id-url": {
+                "value": "http://extId/1"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": null,
+        "contributors": {
+          "contributor": [
+            {
+              "contributor-orcid": {
+                "uri": "https://orcid.org/0000-0002-5391-5437",
+                "path": "0000-0002-5391-5437",
+                "host": "orcid.org"
+              },
+              "credit-name": {
+                "value": "Jordan"
+              },
+              "contributor-email": "example@example.com",
+              "contributor-attributes": {
+                "contributor-sequence": "first",
+                "contributor-role": "author"
+              }
+            },
+            {
+              "contributor-orcid": {
+                "uri": "https://orcid.org/0000-0002-4325-871X",
+                "path": "0000-0002-4325-871X",
+                "host": "orcid.org"
+              },
+              "credit-name": {
+                "value": "Fran"
+              },
+              "contributor-email": null,
+              "contributor-attributes": {
+                "contributor-sequence": "additional",
+                "contributor-role": "author"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 2"
+          }
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": "Short description of the work",
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2020"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1002/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": null,
+        "contributors": {
+          "contributor": [
+            {
+              "contributor-orcid": {
+                "uri": "https://orcid.org/0000-0002-5391-5437",
+                "path": "0000-0002-5391-5437",
+                "host": "orcid.org"
+              },
+              "credit-name": {
+                "value": "Jordan"
+              },
+              "contributor-email": "example@example.com",
+              "contributor-attributes": {
+                "contributor-sequence": "first",
+                "contributor-role": "author"
+              }
+            },
+            {
+              "contributor-orcid": {
+                "uri": "https://orcid.org/0000-0002-4325-871X",
+                "path": "0000-0002-4325-871X",
+                "host": "orcid.org"
+              },
+              "credit-name": {
+                "value": "Fran"
+              },
+              "contributor-email": null,
+              "contributor-attributes": {
+                "contributor-sequence": "additional",
+                "contributor-role": "author"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 3"
+          }
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2019"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1003/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": [{
+            "contributor-orcid": {
+              "uri": "https://orcid.org/0000-0002-5391-5437",
+              "path": "0000-0002-5391-5437",
+              "host": "orcid.org"
+            },
+            "credit-name": {
+              "value": "Jordan"
+            },
+            "contributor-email": "example@example.com",
+            "contributor-attributes": {
+              "contributor-sequence": "first",
+              "contributor-role": "author"
+            }
+          },
+          {
+            "contributor-orcid": {
+              "uri": "https://orcid.org/0000-0002-4325-871X",
+              "path": "0000-0002-4325-871X",
+              "host": "orcid.org"
+            },
+            "credit-name": {
+              "value": "Fran"
+            },
+            "contributor-email": null,
+            "contributor-attributes": {
+              "contributor-sequence": "additional",
+              "contributor-role": "author"
+            }
+          }]
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 4"
+          }
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": {
+          "citation-type": "bibtex",
+          "citation-value": "\n\t\t\t@article {ORCID2012,\n\t\t\t\ttitle = \"ORCID: a system to uniquely identify researchers\",\n\t\t\t\tjournal = \"Learned Publishing\",\n\t\t\t\tyear = \"2022\",\n\t\t\t\tdoi = \"doi:10.1087/20140404\"\n\t\t\t\t}\n\t\t"
+        },
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2018"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1004/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": [{
+            "contributor-orcid": {
+              "uri": "https://orcid.org/0000-0002-5391-5437",
+              "path": "0000-0002-5391-5437",
+              "host": "orcid.org"
+            },
+            "credit-name": {
+              "value": "Jordan"
+            },
+            "contributor-email": "example@example.com",
+            "contributor-attributes": {
+              "contributor-sequence": "first",
+              "contributor-role": "author"
+            }
+          },
+          {
+            "contributor-orcid": {
+              "uri": "https://orcid.org/0000-0002-4325-871X",
+              "path": "0000-0002-4325-871X",
+              "host": "orcid.org"
+            },
+            "credit-name": {
+              "value": "Fran"
+            },
+            "contributor-email": null,
+            "contributor-attributes": {
+              "contributor-sequence": "additional",
+              "contributor-role": "author"
+            }
+          }]
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 5"
+          }
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": {
+          "citation-type": "bibtex",
+          "citation-value": "\n\t\t\t@article {ORCID2012,\n\t\t\t\ttitle = \"ORCID: a system to uniquely identify researchers\",\n\t\t\t\tjournal = \"Learned Publishing\",\n\t\t\t\tyear = \"2022\",\n\t\t\t\tdoi = \"doi:10.1087/20140404\"\n\t\t\t\t}\n\t\t"
+        },
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2017"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1005/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 6"
+          }
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": {
+          "citation-type": "bibtex",
+          "citation-value": "\n\t\t\t@article {ORCID2012,\n\t\t\t\ttitle = \"ORCID: a system to uniquely identify researchers\",\n\t\t\t\tjournal = \"Learned Publishing\",\n\t\t\t\tyear = \"2022\",\n\t\t\t\tdoi = \"doi:10.1087/20140404\"\n\t\t\t\t}\n\t\t"
+        },
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2016"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1006/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 7"
+          }
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": {
+          "citation-type": "bibtex",
+          "citation-value": "\n\t\t\t@article {ORCID2012,\n\t\t\t\ttitle = \"ORCID: a system to uniquely identify researchers\",\n\t\t\t\tjournal = \"Learned Publishing\",\n\t\t\t\tyear = \"2022\",\n\t\t\t\tdoi = \"doi:10.1087/20140404\"\n\t\t\t\t}\n\t\t"
+        },
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2015"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1007/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": [
+            {
+              "contributor-orcid": {
+                "uri": "https://orcid.org/0000-0002-4856-5225",
+                "path": "0000-0002-4856-5225",
+                "host": "orcid.org"
+              },
+              "credit-name": {
+                "value": "Sam"
+              },
+              "contributor-email": null,
+              "contributor-attributes": {
+                "contributor-sequence": "additional",
+                "contributor-role": "http://credit.niso.org/contributor-roles/visualization/"
+              }
+            },
+            {
+              "contributor-orcid": {
+                "uri": "https://orcid.org/0000-0002-7174-6139",
+                "path": "0000-0002-7174-6139",
+                "host": "orcid.org"
+              },
+              "credit-name": {
+                "value": "Jordan"
+              },
+              "contributor-email": null,
+              "contributor-attributes": {
+                "contributor-sequence": "additional",
+                "contributor-role": "http://credit.niso.org/contributor-roles/validation/"
+              }
+            },
+            {
+              "contributor-orcid": {
+                "uri": "https://orcid.org/0000-0002-1198-7731",
+                "path": "0000-0002-1198-7731",
+                "host": "orcid.org"
+              },
+              "credit-name": {
+                "value": "Frank"
+              },
+              "contributor-email": null,
+              "contributor-attributes": {
+                "contributor-sequence": "additional",
+                "contributor-role": "http://credit.niso.org/contributor-roles/supervision/"
+              }
+            }
+          ]
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 8"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": {
+          "citation-type": "bibtex",
+          "citation-value": "\n\t\t\t@article {ORCID2012,\n\t\t\t\ttitle = \"ORCID: a system to uniquely identify researchers\",\n\t\t\t\tjournal = \"Learned Publishing\",\n\t\t\t\tyear = \"2022\",\n\t\t\t\tdoi = \"doi:10.1087/20140404\"\n\t\t\t\t}\n\t\t"
+        },
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2014"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1008/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 9"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": {
+          "citation-type": "bibtex",
+          "citation-value": "\n\t\t\t@article {ORCID2012,\n\t\t\t\ttitle = \"ORCID: a system to uniquely identify researchers\",\n\t\t\t\tjournal = \"Learned Publishing\",\n\t\t\t\tyear = \"2022\",\n\t\t\t\tdoi = \"doi:10.1087/20140404\"\n\t\t\t\t}\n\t\t"
+        },
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2013"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1009/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 10"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": {
+          "citation-type": "bibtex",
+          "citation-value": "\n\t\t\t@article {ORCID2012,\n\t\t\t\ttitle = \"ORCID: a system to uniquely identify researchers\",\n\t\t\t\tjournal = \"Learned Publishing\",\n\t\t\t\tyear = \"2022\",\n\t\t\t\tdoi = \"doi:10.1087/20140404\"\n\t\t\t\t}\n\t\t"
+        },
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2012"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1010/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 11"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2011"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1011/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 12"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2010"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1012/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 13"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2009"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1013/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 14"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2008"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1014/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 15"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2007"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1015/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 16"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2006"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1016/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 17"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2005"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1017/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 18"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2004"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1018/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 19"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2003"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1019/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 20"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2002"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1020/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 21"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2001"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1021/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 22"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2000"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1022/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 23"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1999"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1023/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 24"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1998"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1024/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 25"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1997"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1025/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 26"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1996"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1026/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 27"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1995"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1027/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 28"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1994"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1028/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 29"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1993"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1029/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 30"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1992"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1030/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 31"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1991"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1031/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 32"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1990"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1032/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 33"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1989"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1033/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 33"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1988"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1034/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 35"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1987"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1035/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 36"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1986"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1036/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 37"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1985"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1037/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 38"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1984"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1038/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 39"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1983"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1039/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 40"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1982"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1040/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 41"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1981"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1041/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 42"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1980"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1042/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 43"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1979"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1043/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 44"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1978"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1044/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 45"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1977"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1045/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 46"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1976"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1046/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 47"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1975"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1047/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 48"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1974"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1048/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 49"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1973"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1049/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 50"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1972"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1050/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 51"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1971"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1051/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 52"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1970"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1052/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 53"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1969"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1053/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 54"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1968"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1054/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 55"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1967"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1055/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 56"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1966"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1056/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 57"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1965"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1057/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 58"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1964"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1058/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 59"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1963"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1059/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 60"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1962"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1060/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 61"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1961"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1061/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 62"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1960"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1062/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 63"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1959"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1063/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 64"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1958"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1064/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 65"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1957"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1065/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 66"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1956"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1066/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 67"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1955"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1067/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 68"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1954"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1068/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 69"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1953"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1069/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 70"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1953"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1070/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 71"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1952"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1071/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 72"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1951"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1072/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 73"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1950"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1073/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 74"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1949"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1074/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 75"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1948"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1075/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 76"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1947"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1076/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 77"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1946"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1077/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 78"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1945"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1078/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 79"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1944"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1079/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 80"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1943"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1080/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 81"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1942"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1081/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 82"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1941"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1082/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 83"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1940"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1083/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 84"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1939"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1084/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 85"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1938"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1085/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 86"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1937"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1086/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 87"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1936"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1087/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 88"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1935"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1088/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 89"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1934"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1089/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 90"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1933"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1090/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 91"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1932"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1091/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 92"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1931"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1092/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 93"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1930"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1093/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 94"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1929"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1094/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 95"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1928"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1095/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 96"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1927"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1096/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 97"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1926"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1097/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 98"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1925"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1098/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 99"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1924"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1099/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 100"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Cor et Vasa"
+        },
+        "short-description": null,
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "1923"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1100/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    }
+  ]
+}

--- a/src/main/resources/record_3.0/samples/write_samples/bulk-works-3-works-3.0.json
+++ b/src/main/resources/record_3.0/samples/write_samples/bulk-works-3-works-3.0.json
@@ -1,0 +1,162 @@
+{
+  "bulk": [
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 1"
+          },
+          "subtitle": "Work 1 subtitle",
+          "translated-title": {
+            "value": "Translated-title English",
+            "language-code": "en"
+          }
+        },
+        "journal-title": {
+          "value": "Journal Title"
+        },
+        "short-description": "Description",
+        "citation": null,
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2015"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1026/j.crvasa.2015.05.007",
+              "external-id-url": {
+                "value": "http://extId/1"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": null,
+        "contributors": {
+          "contributor": []
+        },
+        "language-code": null,
+        "country": null,
+        "visibility": "public"
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 2"
+          },
+          "subtitle": null,
+          "translated-title": null
+        },
+        "journal-title": {
+          "value": "Journal Title"
+        },
+        "short-description": "Short description",
+        "citation": {
+          "citation-type": "bibtex",
+          "citation-value": "\n\t\t\t@article {ORCID2012,\n\t\t\t\ttitle = \"ORCID: a system to uniquely identify researchers\",\n\t\t\t\tjournal = \"Learned Publishing\",\n\t\t\t\tyear = \"2022\",\n\t\t\t\tdoi = \"doi:10.1087/20140404\"\n\t\t\t\t}\n\t\t"
+        },
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2015"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1012/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": "https://example.com",
+        "contributors": {
+          "contributor": [
+            {
+              "contributor-orcid": {
+                "uri": "https://orcid.org/0000-0002-5391-5437",
+                "path": "0000-0002-5391-5437",
+                "host": "orcid.org"
+              },
+              "credit-name": {
+                "value": "Jordan"
+              },
+              "contributor-email": null,
+              "contributor-attributes": {
+                "contributor-sequence": "first",
+                "contributor-role": "author"
+              }
+            }
+          ]
+        },
+        "country": null
+      }
+    },
+    {
+      "work": {
+        "title": {
+          "title": {
+            "value": "Work Title 3"
+          },
+          "subtitle": "Work 3 subtitle"
+        },
+        "journal-title": {
+          "value": "Another journal title"
+        },
+        "short-description": "Short description",
+        "type": "journal-article",
+        "publication-date": {
+          "year": {
+            "value": "2015"
+          },
+          "month": {
+            "value": "06"
+          },
+          "day": {
+            "value": "01"
+          }
+        },
+        "external-ids": {
+          "external-id": [
+            {
+              "external-id-type": "doi",
+              "external-id-value": "10.1032/j.crvasa.2015.05.008",
+              "external-id-url": {
+                "value": "http://extId/2"
+              },
+              "external-id-relationship": "self"
+            }
+          ]
+        },
+        "url": {
+          "value": "https://example.com"
+        },
+        "contributors": {
+          "contributor": []
+        }
+      }
+    }
+  ]
+}

--- a/src/main/resources/record_3.0/samples/write_samples/distinction-3.0.json
+++ b/src/main/resources/record_3.0/samples/write_samples/distinction-3.0.json
@@ -1,0 +1,69 @@
+{
+  "department-name": "Department",
+  "role-title": "Role",
+  "start-date": {
+    "year": {
+      "value": "2022"
+    },
+    "month": {
+      "value": "01"
+    },
+    "day": {
+      "value": "01"
+    }
+  },
+  "end-date": {
+    "year": {
+      "value": "2023"
+    },
+    "month": {
+      "value": "01"
+    },
+    "day": {
+      "value": "02"
+    }
+  },
+  "organization": {
+    "name": "University of Michigan",
+    "address": {
+      "city": "Ann Arbor",
+      "region": "Michigan",
+      "country": "US"
+    },
+    "disambiguated-organization": {
+      "disambiguated-organization-identifier": "https://ror.org/00jmfr291",
+      "disambiguation-source": "ROR"
+    }
+  },
+  "url": {
+    "value": "https://example.com/org-url"
+  },
+  "external-ids": {
+    "external-id": [
+      {
+        "external-id-type": "grant_number",
+        "external-id-value": "external-identifier-value",
+        "external-id-url": {
+          "value": "http://tempuri.org"
+        },
+        "external-id-relationship": "self"
+      },
+      {
+        "external-id-type": "grant_number",
+        "external-id-value": "external-identifier-value2",
+        "external-id-url": {
+          "value": "http://tempuri.org/2"
+        },
+        "external-id-relationship": "self"
+      },
+      {
+        "external-id-type": "grant_number",
+        "external-id-value": "external-identifier-value3",
+        "external-id-url": {
+          "value": "http://tempuri.org/3"
+        },
+        "external-id-relationship": "part-of"
+      }
+    ]
+  }
+}

--- a/src/main/resources/record_3.0/samples/write_samples/education-3.0.json
+++ b/src/main/resources/record_3.0/samples/write_samples/education-3.0.json
@@ -1,0 +1,69 @@
+{
+  "department-name": "School of Geography and the Environment",
+  "role-title": "Degree awarded",
+  "start-date": {
+    "year": {
+      "value": "2015"
+    },
+    "month": {
+      "value": "02"
+    },
+    "day": {
+      "value": "02"
+    }
+  },
+  "end-date": {
+    "year": {
+      "value": "2023"
+    },
+    "month": {
+      "value": "01"
+    },
+    "day": {
+      "value": "02"
+    }
+  },
+  "organization": {
+    "name": "University of Oxford",
+    "address": {
+      "city": "Oxford",
+      "region": "Oxfordshire",
+      "country": "GB"
+    },
+    "disambiguated-organization": {
+      "disambiguated-organization-identifier": "https://ror.org/052gg0110",
+      "disambiguation-source": "ROR"
+    }
+  },
+  "url": {
+    "value": "http://tempuri.org"
+  },
+  "external-ids": {
+    "external-id": [
+      {
+        "external-id-type": "grant_number",
+        "external-id-value": "external-identifier-value",
+        "external-id-url": {
+          "value": "http://tempuri.org"
+        },
+        "external-id-relationship": "self"
+      },
+      {
+        "external-id-type": "proposal-id",
+        "external-id-value": "external-identifier-value2",
+        "external-id-url": {
+          "value": "http://tempuri.org/2"
+        },
+        "external-id-relationship": "self"
+      },
+      {
+        "external-id-type": "grant_number",
+        "external-id-value": "external-identifier-value2",
+        "external-id-url": {
+          "value": "http://tempuri.org/2"
+        },
+        "external-id-relationship": "part-of"
+      }
+    ]
+  }
+}

--- a/src/main/resources/record_3.0/samples/write_samples/employment-3.0.json
+++ b/src/main/resources/record_3.0/samples/write_samples/employment-3.0.json
@@ -1,0 +1,69 @@
+{
+  "department-name": "Primary Care Health Services",
+  "role-title": "Role",
+  "start-date": {
+    "year": {
+      "value": "2021"
+    },
+    "month": {
+      "value": "01"
+    },
+    "day": {
+      "value": "01"
+    }
+  },
+  "end-date": {
+    "year": {
+      "value": "2023"
+    },
+    "month": {
+      "value": "01"
+    },
+    "day": {
+      "value": "01"
+    }
+  },
+  "organization": {
+    "name": "Boston University",
+    "address": {
+      "city": "Boston",
+      "region": "Massachusetts",
+      "country": "US"
+    },
+    "disambiguated-organization": {
+      "disambiguated-organization-identifier": "https://ror.org/05qwgg493",
+      "disambiguation-source": "ROR"
+    }
+  },
+  "url": {
+    "value": "https://example.com"
+  },
+  "external-ids": {
+    "external-id": [
+      {
+        "external-id-type": "grant_number",
+        "external-id-value": "external-identifier-value",
+        "external-id-url": {
+          "value": "http://tempuri.org"
+        },
+        "external-id-relationship": "self"
+      },
+      {
+        "external-id-type": "grant_number",
+        "external-id-value": "external-identifier-value2",
+        "external-id-url": {
+          "value": "http://tempuri.org/2"
+        },
+        "external-id-relationship": "self"
+      },
+      {
+        "external-id-type": "doi",
+        "external-id-value": "http://dx.doi.org/10.13339/120000001",
+        "external-id-url": {
+          "value": "https://example.com/id-url"
+        },
+        "external-id-relationship": "part-of"
+      }
+    ]
+  }
+}

--- a/src/main/resources/record_3.0/samples/write_samples/external-identifier-3.0.json
+++ b/src/main/resources/record_3.0/samples/write_samples/external-identifier-3.0.json
@@ -1,0 +1,8 @@
+{
+  "external-id-type": "My ID System",
+  "external-id-value": "A-0003",
+  "external-id-url": {
+    "value": "https://myid.com/A-0003"
+  },
+  "external-id-relationship": "self"
+}

--- a/src/main/resources/record_3.0/samples/write_samples/funding-3.0-simple.json
+++ b/src/main/resources/record_3.0/samples/write_samples/funding-3.0-simple.json
@@ -1,0 +1,89 @@
+{
+  "type": "grant",
+  "organization-defined-type": {
+    "value": "Funding sub-type"
+  },
+  "title": {
+    "title": {
+      "value": "Grant title"
+    },
+    "translated-title": {
+      "value": "Translated title",
+      "language-code": "en"
+    }
+  },
+  "short-description": "Short description for the funding.",
+  "amount": {
+    "value": "1000.0",
+    "currency-code": "ADP"
+  },
+  "url": {
+    "value": "https://alt-url.org"
+  },
+  "start-date": {
+    "year": {
+      "value": "2000"
+    },
+    "month": {
+      "value": "02"
+    },
+    "day": {
+      "value": "02"
+    }
+  },
+  "end-date": {
+    "year": {
+      "value": "2020"
+    },
+    "month": {
+      "value": "02"
+    },
+    "day": {
+      "value": "02"
+    }
+  },
+  "external-ids": {
+    "external-id": [
+      {
+        "external-id-type": "grant_number",
+        "external-id-value": "987654321",
+        "external-id-url": {
+          "value": "http://orcid.org"
+        },
+        "external-id-relationship": "self"
+      },
+      {
+        "external-id-type": "grant_number",
+        "external-id-value": "PTDC/NEU",
+        "external-id-url": {
+          "value": "http://orcid.org"
+        },
+        "external-id-relationship": "self"
+      },
+      {
+        "external-id-type": "grant_number",
+        "external-id-value": "1234567",
+
+        "external-id-url": {
+          "value": "https://doi.org/10.1087/20120404"
+        },
+        "external-id-relationship": "part-of"
+      }
+    ]
+  },
+  "contributors": {
+    "contributor": []
+  },
+  "organization": {
+    "name": "ORCID",
+    "address": {
+      "city": "Bethesda",
+      "region": "Maryland",
+      "country": "US"
+    },
+    "disambiguated-organization": {
+      "disambiguated-organization-identifier": "https://ror.org/04fa4r544",
+      "disambiguation-source": "ROR"
+    }
+  }
+}

--- a/src/main/resources/record_3.0/samples/write_samples/funding-3.0-with-NISO-roles.json
+++ b/src/main/resources/record_3.0/samples/write_samples/funding-3.0-with-NISO-roles.json
@@ -1,0 +1,334 @@
+{
+  "type": "grant",
+  "organization-defined-type": {
+    "value": "Funding sub-type"
+  },
+  "title": {
+    "title": {
+      "value": "Grant title"
+    },
+    "translated-title": {
+      "value": "Translated title",
+      "language-code": "en"
+    }
+  },
+  "short-description": "Short description for the funding.",
+  "amount": {
+    "value": "1000.0",
+    "currency-code": "ADP"
+  },
+  "url": {
+    "value": "https://alt-url.org"
+  },
+  "start-date": {
+    "year": {
+      "value": "2000"
+    },
+    "month": {
+      "value": "02"
+    },
+    "day": {
+      "value": "02"
+    }
+  },
+  "end-date": {
+    "year": {
+      "value": "2020"
+    },
+    "month": {
+      "value": "02"
+    },
+    "day": {
+      "value": "02"
+    }
+  },
+  "external-ids": {
+    "external-id": [
+      {
+        "external-id-type": "grant_number",
+        "external-id-value": "1234567",
+
+        "external-id-url": {
+          "value": "https://doi.org/10.1087/20120404"
+        },
+        "external-id-relationship": "part-of"
+      },
+      {
+        "external-id-type": "grant_number",
+        "external-id-value": "PTDC/NEU",
+        "external-id-url": {
+          "value": "http://orcid.org"
+        },
+        "external-id-relationship": "self"
+      }
+    ]
+  },
+  "contributors": {
+    "contributor": [
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-5391-5437",
+          "path": "0000-0002-5391-5437",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Jordan Holt"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-role": "lead"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-4325-871X",
+          "path": "0000-0002-4325-871X",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Fran Alsina"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-role": "co-lead"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-4685-4189",
+          "path": "0000-0002-4685-4189",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Frank"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-role": "supported-by"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-2990-7971",
+          "path": "0000-0002-2990-7971",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Özcan"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-role": "other-contribution"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-2428-8059",
+          "path": "0000-0002-2428-8059",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Filip"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-role": "http://credit.niso.org/contributor-roles/writing-review-editing/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-6546-5501",
+          "path": "0000-0001-6546-5501",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Bulu"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-role": "http://credit.niso.org/contributor-roles/writing-original-draft/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-7249-4079",
+          "path": "0000-0001-7249-4079",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Francisco"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-role": "http://credit.niso.org/contributor-roles/visualization/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-1601-6950",
+          "path": "0000-0002-1601-6950",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Amelya Betsalonia"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-role": "http://credit.niso.org/contributor-roles/validation/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-3409-1361",
+          "path": "0000-0003-3409-1361",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Aslan Yavuz"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-role": "http://credit.niso.org/contributor-roles/supervision/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-6851-3502",
+          "path": "0000-0002-6851-3502",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Sir-yeon"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-role": "http://credit.niso.org/contributor-roles/software/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-6634-4071",
+          "path": "0000-0002-6634-4071",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Miloslav"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-role": "http://credit.niso.org/contributor-roles/resources/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-3043-2835",
+          "path": "0000-0003-3043-2835",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Sir Theoneste"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-role": "http://credit.niso.org/contributor-roles/project-administration/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-2136-9360",
+          "path": "0000-0003-2136-9360",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Robert"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-role": "http://credit.niso.org/contributor-roles/methodology/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-4944-4334",
+          "path": "0000-0003-4944-4334",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Lynn"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-role": "http://credit.niso.org/contributor-roles/investigation/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-0497-2910",
+          "path": "0000-0002-0497-2910",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Jeremy"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-role": "http://credit.niso.org/contributor-roles/funding-acquisition/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-7642-8906",
+          "path": "0000-0002-7642-8906",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Adrienne"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-role": "http://credit.niso.org/contributor-roles/formal-analysis/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-2428-4058",
+          "path": "0000-0002-2428-4058",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Mihaela"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-role": "http://credit.niso.org/contributor-roles/data-curation/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-3445-5428",
+          "path": "0000-0003-3445-5428",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Mitchell"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-role": "http://credit.niso.org/contributor-roles/conceptualization/"
+        }
+      }
+    ]
+  },
+  "organization": {
+    "name": "Wellcome Trust",
+    "address": {
+      "city": "London",
+      "region": null,
+      "country": "GB"
+    },
+    "disambiguated-organization": {
+      "disambiguated-organization-identifier": "https://ror.org/033jnv181",
+      "disambiguation-source": "ROR"
+    }
+  }
+}

--- a/src/main/resources/record_3.0/samples/write_samples/invited-position-3.0.json
+++ b/src/main/resources/record_3.0/samples/write_samples/invited-position-3.0.json
@@ -1,0 +1,69 @@
+{
+  "department-name": "Department",
+  "role-title": "Role",
+  "start-date": {
+    "year": {
+      "value": "2022"
+    },
+    "month": {
+      "value": "01"
+    },
+    "day": {
+      "value": "01"
+    }
+  },
+  "end-date": {
+    "year": {
+      "value": "2023"
+    },
+    "month": {
+      "value": "01"
+    },
+    "day": {
+      "value": "01"
+    }
+  },
+  "organization": {
+    "name": "University of Toronto",
+    "address": {
+      "city": "Toronto",
+      "region": "Ontario",
+      "country": "CA"
+    },
+    "disambiguated-organization": {
+      "disambiguated-organization-identifier": "https://ror.org/03dbr7087",
+      "disambiguation-source": "ROR"
+    }
+  },
+  "url": {
+    "value": "https://example.come/url"
+  },
+  "external-ids": {
+    "external-id": [
+      {
+        "external-id-type": "grant_number",
+        "external-id-value": "external-identifier-value",
+        "external-id-url": {
+          "value": "http://tempuri.org"
+        },
+        "external-id-relationship": "self"
+      },
+      {
+        "external-id-type": "grant_number",
+        "external-id-value": "external-identifier-value2",
+        "external-id-url": {
+          "value": "http://tempuri.org/2"
+        },
+        "external-id-relationship": "self"
+      },
+      {
+        "external-id-type": "emdb",
+        "external-id-value": "https://www.ebi.ac.uk/emdb/EMD-1001",
+        "external-id-url": {
+          "value": "https://www.ebi.ac.uk/emdb/EMD-1001"
+        },
+        "external-id-relationship": "part-of"
+      }
+    ]
+  }
+}

--- a/src/main/resources/record_3.0/samples/write_samples/keywords-3.0.json
+++ b/src/main/resources/record_3.0/samples/write_samples/keywords-3.0.json
@@ -1,0 +1,3 @@
+{
+  "content": "keyword"
+}

--- a/src/main/resources/record_3.0/samples/write_samples/membership-3.0.json
+++ b/src/main/resources/record_3.0/samples/write_samples/membership-3.0.json
@@ -1,0 +1,61 @@
+{
+  "department-name": "Department",
+  "role-title": "Role",
+  "start-date": {
+    "year": {
+      "value": "2021"
+    },
+    "month": {
+      "value": "02"
+    },
+    "day": {
+      "value": "02"
+    }
+  },
+  "end-date": {
+    "year": {
+      "value": "2023"
+    },
+    "month": {
+      "value": "01"
+    },
+    "day": {
+      "value": "02"
+    }
+  },
+  "organization": {
+    "name": "Research Data Alliance",
+    "address": {
+      "city": "Dublin",
+      "region": "Province of Leinster",
+      "country": "IE"
+    },
+    "disambiguated-organization": {
+      "disambiguated-organization-identifier": "https://ror.org/05dc6w374",
+      "disambiguation-source": "ROR"
+    }
+  },
+  "url": {
+    "value": "http://tempuri.org"
+  },
+  "external-ids": {
+    "external-id": [
+      {
+        "external-id-type": "grant_number",
+        "external-id-value": "external-identifier-value",
+        "external-id-url": {
+          "value": "http://tempuri.org"
+        },
+        "external-id-relationship": "self"
+      },
+      {
+        "external-id-type": "grant_number",
+        "external-id-value": "external-identifier-value2",
+        "external-id-url": {
+          "value": "http://tempuri.org/2"
+        },
+        "external-id-relationship": "self"
+      }
+    ]
+  }
+}

--- a/src/main/resources/record_3.0/samples/write_samples/other-names-3.0.json
+++ b/src/main/resources/record_3.0/samples/write_samples/other-names-3.0.json
@@ -1,0 +1,3 @@
+{
+  "content": "Other Name"
+}

--- a/src/main/resources/record_3.0/samples/write_samples/peer-review-full-3.0-award-subject-type.json
+++ b/src/main/resources/record_3.0/samples/write_samples/peer-review-full-3.0-award-subject-type.json
@@ -1,0 +1,72 @@
+{
+  "reviewer-role": "reviewer",
+  "review-identifiers": {
+    "external-id": [
+      {
+        "external-id-type": "source-work-id",
+        "external-id-value": "12345",
+        "external-id-url": {
+          "value": "https://example.com/1234"
+        },
+        "external-id-relationship": "self"
+      },
+      {
+        "external-id-type": "source-work-id",
+        "external-id-value": "987654321",
+        "external-id-url": {
+          "value": "https://example.com/9876"
+        },
+        "external-id-relationship": "part-of"
+      }
+    ]
+  },
+  "review-url": "https://example.com",
+  "review-type": "review",
+  "review-completion-date": {
+    "year": {
+      "value": "2012"
+    },
+    "month": {
+      "value": "04"
+    },
+    "day": {
+      "value": "14"
+    }
+  },
+  "review-group-id": "issn:1741-4857",
+  "subject-external-identifier": {
+    "external-id-type": "doi",
+    "external-id-value": "10.1087/20120404",
+    "external-id-url": {
+      "value": "https://doi.org/10.1087/20120404"
+    },
+    "external-id-relationship": "self"
+  },
+  "subject-container-name": "Award title",
+  "subject-type": "award",
+  "subject-name": {
+    "title": {
+      "value": "Name of the paper reviewed"
+    },
+    "subtitle": {
+      "value": "Review subtitle"
+    },
+    "translated-title": {
+      "value": "Subject name translated title",
+      "language-code": "en"
+    }
+  },
+  "subject-url": "https://example.com/review-item",
+  "convening-organization": {
+    "name": "ORCID",
+    "address": {
+      "city": "Bethesda",
+      "region": "MD",
+      "country": "US"
+    },
+    "disambiguated-organization": {
+      "disambiguated-organization-identifier": "https://ror.org/04fa4r544",
+      "disambiguation-source": "ROR"
+    }
+  }
+}

--- a/src/main/resources/record_3.0/samples/write_samples/peer-review-full-3.0-research-resource.json
+++ b/src/main/resources/record_3.0/samples/write_samples/peer-review-full-3.0-research-resource.json
@@ -1,0 +1,72 @@
+{
+  "reviewer-role": "reviewer",
+  "review-identifiers": {
+    "external-id": [
+      {
+        "external-id-type": "source-work-id",
+        "external-id-value": "98765",
+        "external-id-url": {
+          "value": "https://example.com/98765"
+        },
+        "external-id-relationship": "self"
+      },
+      {
+        "external-id-type": "source-work-id",
+        "external-id-value": "123456",
+        "external-id-url": {
+          "value": "https://example.com/123456"
+        },
+        "external-id-relationship": "part-of"
+      }
+    ]
+  },
+  "review-url": "https://example.com",
+  "review-type": "review",
+  "review-completion-date": {
+    "year": {
+      "value": "2012"
+    },
+    "month": {
+      "value": "04"
+    },
+    "day": {
+      "value": "14"
+    }
+  },
+  "review-group-id": "issn:1741-4857",
+  "subject-external-identifier": {
+    "external-id-type": "doi",
+    "external-id-value": "10.80413/c4z0-kg94",
+    "external-id-url": {
+      "value": "https://localsystem.org/1234"
+    },
+    "external-id-relationship": "self"
+  },
+  "subject-container-name": "Research Resource Title",
+  "subject-type": "research-resource-proposal",
+  "subject-name": {
+    "title": {
+      "value": "Review subject name"
+    },
+    "subtitle": {
+      "value": "Review subtitle"
+    },
+    "translated-title": {
+      "value": "Subject name translated title",
+      "language-code": "en"
+    }
+  },
+  "subject-url": "https://example.com/review-item",
+  "convening-organization": {
+    "name": "ORCID",
+    "address": {
+      "city": "Bethesda",
+      "region": "MD",
+      "country": "US"
+    },
+    "disambiguated-organization": {
+      "disambiguated-organization-identifier": "https://ror.org/04fa4r544",
+      "disambiguation-source": "ROR"
+    }
+  }
+}

--- a/src/main/resources/record_3.0/samples/write_samples/peer-review-full-3.0.json
+++ b/src/main/resources/record_3.0/samples/write_samples/peer-review-full-3.0.json
@@ -1,0 +1,72 @@
+{
+  "reviewer-role": "reviewer",
+  "review-identifiers": {
+    "external-id": [
+      {
+        "external-id-type": "source-work-id",
+        "external-id-value": "98765",
+        "external-id-url": {
+          "value": "https://example.com/98765"
+        },
+        "external-id-relationship": "self"
+      },
+      {
+        "external-id-type": "source-work-id",
+        "external-id-value": "123456",
+        "external-id-url": {
+          "value": "https://example.com/123456"
+        },
+        "external-id-relationship": "part-of"
+      }
+    ]
+  },
+  "review-url": "https://example.com",
+  "review-type": "review",
+  "review-completion-date": {
+    "year": {
+      "value": "2012"
+    },
+    "month": {
+      "value": "04"
+    },
+    "day": {
+      "value": "14"
+    }
+  },
+  "review-group-id": "issn:1741-4857",
+  "subject-external-identifier": {
+    "external-id-type": "doi",
+    "external-id-value": "10.1087/20120404",
+    "external-id-url": {
+      "value": "https://doi.org/10.1087/20120404"
+    },
+    "external-id-relationship": "self"
+  },
+  "subject-container-name": "Journal title",
+  "subject-type": "journal-article",
+  "subject-name": {
+    "title": {
+      "value": "Name of the paper reviewed"
+    },
+    "subtitle": {
+      "value": "Review subtitle"
+    },
+    "translated-title": {
+      "value": "Subject name translated title",
+      "language-code": "en"
+    }
+  },
+  "subject-url": "https://example.com/review-item",
+  "convening-organization": {
+    "name": "ORCID",
+    "address": {
+      "city": "Bethesda",
+      "region": "MD",
+      "country": "US"
+    },
+    "disambiguated-organization": {
+      "disambiguated-organization-identifier": "https://ror.org/04fa4r544",
+      "disambiguation-source": "ROR"
+    }
+  }
+}

--- a/src/main/resources/record_3.0/samples/write_samples/peer-review-group-id.json
+++ b/src/main/resources/record_3.0/samples/write_samples/peer-review-group-id.json
@@ -1,0 +1,6 @@
+{
+    "name": "Group ID name",
+    "group-id": "ringgold:355321",
+    "description": "Description for a peer-review group id.",
+    "type": "magazine"
+  }

--- a/src/main/resources/record_3.0/samples/write_samples/peer-review-simple-3.0.json
+++ b/src/main/resources/record_3.0/samples/write_samples/peer-review-simple-3.0.json
@@ -1,0 +1,35 @@
+{
+  "reviewer-role": "reviewer",
+  "review-identifiers": {
+    "external-id": [
+      {
+        "external-id-type": "source-work-id",
+        "external-id-value": "123456",
+        "external-id-url": {
+          "value": "https://localsystem.org/1234"
+        },
+        "external-id-relationship": "self"
+      }
+    ]
+  },
+  "review-url": "https://example.com",
+  "review-type": "review",
+  "review-completion-date": {
+    "year": {
+      "value": "2012"
+    }
+  },
+  "review-group-id": "issn:1741-4857",
+  "convening-organization": {
+    "name": "ORCID",
+    "address": {
+      "city": "Bethesda",
+      "region": "MD",
+      "country": "US"
+    },
+    "disambiguated-organization": {
+      "disambiguated-organization-identifier": "385488",
+      "disambiguation-source": "RINGGOLD"
+    }
+  }
+}

--- a/src/main/resources/record_3.0/samples/write_samples/qualification-3.0.json
+++ b/src/main/resources/record_3.0/samples/write_samples/qualification-3.0.json
@@ -1,0 +1,61 @@
+{
+  "department-name": "Systems Engineering & Engineering",
+  "role-title": "Foundations of Aerospace at NASA",
+  "start-date": {
+    "year": {
+      "value": "2022"
+    },
+    "month": {
+      "value": "01"
+    },
+    "day": {
+      "value": "02"
+    }
+  },
+  "end-date": {
+    "year": {
+      "value": "2023"
+    },
+    "month": {
+      "value": "01"
+    },
+    "day": {
+      "value": "02"
+    }
+  },
+  "organization": {
+    "name": "National Aeronautics and Space Administration",
+    "address": {
+      "city": "Washington",
+      "region": "D.C",
+      "country": "US"
+    },
+    "disambiguated-organization": {
+      "disambiguated-organization-identifier": "https://ror.org/027ka1x80",
+      "disambiguation-source": "ROR"
+    }
+  },
+  "url": {
+    "value": "http://tempuri.org"
+  },
+  "external-ids": {
+    "external-id": [
+      {
+        "external-id-type": "other-id",
+        "external-id-value": "external-identifier-value",
+        "external-id-url": {
+          "value": "http://tempuri.org"
+        },
+        "external-id-relationship": "self"
+      },
+      {
+        "external-id-type": "grant_number",
+        "external-id-value": "external-identifier-value2",
+        "external-id-url": {
+          "value": "http://tempuri.org/2"
+        },
+        "external-id-relationship": "part-of"
+      }
+    ]
+  }
+}

--- a/src/main/resources/record_3.0/samples/write_samples/research-resource-3.0.json
+++ b/src/main/resources/record_3.0/samples/write_samples/research-resource-3.0.json
@@ -1,0 +1,269 @@
+{
+  "proposal": {
+    "title": {
+      "title": {
+        "value": "Proposal title"
+      },
+      "translated-title": {
+        "value": "Translated-title English",
+        "language-code": "en"
+      }
+    },
+    "hosts": {
+      "organization": [
+        {
+          "name": "ORCID",
+          "address": {
+            "city": "Bethesda",
+            "region": "Maryland",
+            "country": "US"
+          },
+          "disambiguated-organization": {
+            "disambiguated-organization-identifier": "grid.455335.1",
+            "disambiguation-source": "GRID"
+          }
+        },
+        {
+          "name": "NASA",
+          "address": {
+            "city": "Washington",
+            "region": "D.C",
+            "country": "US"
+          },
+          "disambiguated-organization": {
+            "disambiguated-organization-identifier": "https://ror.org/027ka1x80",
+            "disambiguation-source": "ROR"
+          }
+        }
+      ]
+    },
+    "external-ids": {
+      "external-id": [
+        {
+          "external-id-type": "source-work-id",
+          "external-id-value": "123456",
+          "external-id-url": "https://example.com/123456",
+          "external-id-relationship": "self"
+        },
+        {
+          "external-id-type": "handle",
+          "external-id-value": "https://grants.net/123456",
+          "external-id-url": "https://example.com/123456",
+          "external-id-relationship": "self"
+        },
+        {
+          "external-id-type": "other-id",
+          "external-id-value": "TG001JH",
+          "external-id-url": "https://example.com/TG001JH",
+          "external-id-relationship": "part-of"
+        }
+      ]
+    },
+    "start-date": {
+      "year": {
+        "value": "1999"
+      },
+      "month": {
+        "value": "02"
+      },
+      "day": {
+        "value": "02"
+      }
+    },
+    "end-date": {
+      "year": {
+        "value": "2012"
+      },
+      "month": {
+        "value": "02"
+      },
+      "day": {
+        "value": "02"
+      }
+    },
+    "url": {
+      "value": "http://xsede.org/GiantLaserAward"
+    }
+  },
+  "resource-item": [
+    {
+      "resource-name": "Giant Laser 1",
+      "resource-type": "infrastructures",
+      "hosts": {
+        "organization": [
+          {
+            "name": "Lasers-R-US",
+            "address": {
+              "city": "Bethesda",
+              "region": "Maryland",
+              "country": "US"
+            },
+            "disambiguated-organization": {
+              "disambiguated-organization-identifier": "grid.455335.1",
+              "disambiguation-source": "GRID"
+            }
+          }
+        ]
+      },
+      "external-ids": {
+        "external-id": [
+          {
+            "external-id-type": "rrid",
+            "external-id-value": "rrid:giantLASER",
+            "external-id-url": "https://example.com/giant-laser",
+            "external-id-relationship": "self"
+          },
+          {
+            "external-id-type": "doi",
+            "external-id-value": "10.123/giantlaser",
+            "external-id-url": "https://doi.org/10.123/giantlase",
+            "external-id-relationship": "self"
+          },
+          {
+            "external-id-type": "emdb",
+            "external-id-value": "https://www.ebi.ac.uk/emdb/EMD-10623",
+            "external-id-url": "https://www.ebi.ac.uk/emdb/EMD-10623",
+            "external-id-relationship": "part-of"
+          }
+        ]
+      },
+      "url": "https://example.com"
+    },
+    {
+      "resource-name": "Moon Targets",
+      "resource-type": "infrastructures",
+      "hosts": {
+        "organization": [
+          {
+            "name": "Moon Holdings Ltd",
+            "address": {
+              "city": "Bethesda",
+              "region": "Maryland",
+              "country": "US"
+            },
+            "disambiguated-organization": {
+              "disambiguated-organization-identifier": "grid.455335.1",
+              "disambiguation-source": "GRID"
+            }
+          }
+        ]
+      },
+      "external-ids": {
+        "external-id": [
+          {
+            "external-id-type": "uri",
+            "external-id-value": "https://moon.org/targetOnTheMoon",
+            "external-id-url": null,
+            "external-id-relationship": "part-of"
+          }
+        ]
+      },
+      "url": "https://example.com"
+    },
+    {
+      "resource-name": "Rare Book Collection on Lasers",
+      "resource-type": "collections",
+      "hosts": {
+        "organization": [
+          {
+            "name": "Moon Holdings Ltd",
+            "address": {
+              "city": "Bethesda",
+              "region": "Maryland",
+              "country": "US"
+            },
+            "disambiguated-organization": {
+              "disambiguated-organization-identifier": "grid.455335.1",
+              "disambiguation-source": "GRID"
+            }
+          }
+        ]
+      },
+      "external-ids": {
+        "external-id": [
+          {
+            "external-id-type": "uri",
+            "external-id-value": "https://moon.org/rarebooksaboutlasers",
+            "external-id-url": null,
+            "external-id-relationship": "part-of"
+          }
+        ]
+      },
+      "url": null
+    },
+    {
+      "resource-name": "Giant Computer for Laser",
+      "resource-type": "equipment",
+      "hosts": {
+        "organization": [
+          {
+            "name": "Moon Holdings Ltd",
+            "address": {
+              "city": "Bethesda",
+              "region": "Maryland",
+              "country": "US"
+            },
+            "disambiguated-organization": {
+              "disambiguated-organization-identifier": "grid.455335.1",
+              "disambiguation-source": "GRID"
+            }
+          }
+        ]
+      },
+      "external-ids": {
+        "external-id": [
+          {
+            "external-id-type": "uri",
+            "external-id-value": "https://moon.org/giant-computer-laser",
+            "external-id-url": null,
+            "external-id-relationship": "self"
+          },
+          {
+            "external-id-type": "uri",
+            "external-id-value": "https://moon.org/giant-computers",
+            "external-id-url": null,
+            "external-id-relationship": "part-of"
+          }
+        ]
+      },
+      "url": null
+    },
+    {
+      "resource-name": "Legal advice regarding giant lasers",
+      "resource-type": "services",
+      "hosts": {
+        "organization": [
+          {
+            "name": "Moon Holdings Ltd",
+            "address": {
+              "city": "Bethesda",
+              "region": "Maryland",
+              "country": "US"
+            },
+            "disambiguated-organization": {
+              "disambiguated-organization-identifier": "grid.455335.1",
+              "disambiguation-source": "GRID"
+            }
+          }
+        ]
+      },
+      "external-ids": {
+        "external-id": [
+          {
+            "external-id-type": "uri",
+            "external-id-value": "https://moon.org/is-this-legal",
+            "external-id-url": null,
+            "external-id-relationship": "self"
+          },
+          {
+            "external-id-type": "uri",
+            "external-id-value": "https://moon.org/dont-sue",
+            "external-id-url": null,
+            "external-id-relationship": "part-of"
+          }
+        ]
+      },
+      "url": "https://example.com"
+    }
+  ]
+}

--- a/src/main/resources/record_3.0/samples/write_samples/researcher-url-3.0.json
+++ b/src/main/resources/record_3.0/samples/write_samples/researcher-url-3.0.json
@@ -1,0 +1,6 @@
+{
+  "url-name": "Url name",
+  "url": {
+    "value": "https://example.com"
+  }
+}

--- a/src/main/resources/record_3.0/samples/write_samples/researcher-url-no-name-3.0.json
+++ b/src/main/resources/record_3.0/samples/write_samples/researcher-url-no-name-3.0.json
@@ -1,0 +1,5 @@
+{
+  "url": {
+    "value": "https://example.com"
+  }
+}

--- a/src/main/resources/record_3.0/samples/write_samples/service-3.0.json
+++ b/src/main/resources/record_3.0/samples/write_samples/service-3.0.json
@@ -1,0 +1,69 @@
+{
+  "department-name": "Service Department Name",
+  "role-title": "Role title",
+  "start-date": {
+    "year": {
+      "value": "1948"
+    },
+    "month": {
+      "value": "02"
+    },
+    "day": {
+      "value": "02"
+    }
+  },
+  "end-date": {
+    "year": {
+      "value": "2015"
+    },
+    "month": {
+      "value": "02"
+    },
+    "day": {
+      "value": "02"
+    }
+  },
+  "organization": {
+    "name": "ORCID Inc",
+    "address": {
+      "city": "Bethesda",
+      "region": "Maryland",
+      "country": "US"
+    },
+    "disambiguated-organization": {
+      "disambiguated-organization-identifier": "https://ror.org/04fa4r544",
+      "disambiguation-source": "ROR"
+    }
+  },
+  "url": {
+    "value": "https://example.com/service-url"
+  },
+  "external-ids": {
+    "external-id": [
+      {
+        "external-id-type": "grant_number",
+        "external-id-value": "external-identifier-value",
+        "external-id-url": {
+          "value": "http://tempuri.org"
+        },
+        "external-id-relationship": "self"
+      },
+      {
+        "external-id-type": "grant_number",
+        "external-id-value": "external-identifier-value2",
+        "external-id-url": {
+          "value": "http://tempuri.org/2"
+        },
+        "external-id-relationship": "self"
+      },
+      {
+        "external-id-type": "jstor",
+        "external-id-value": "https://www.jstor.org/journal/14centengmystnew",
+        "external-id-url": {
+          "value": "https://www.jstor.org/journal/14centengmystnew"
+        },
+        "external-id-relationship": "part-of"
+      }
+    ]
+  }
+}

--- a/src/main/resources/record_3.0/samples/write_samples/work-51-contributors-3.0.json
+++ b/src/main/resources/record_3.0/samples/write_samples/work-51-contributors-3.0.json
@@ -1,0 +1,830 @@
+{
+  "title": {
+    "title": {
+      "value": "Work title"
+    },
+    "subtitle": {
+      "value": "Work subtitle"
+    },
+    "translated-title": {
+      "value": "Translated-title English",
+      "language-code": "en"
+    }
+  },
+  "journal-title": {
+    "value": "Journal title"
+  },
+  "short-description": "This is a short description of the work.",
+  "citation": {
+    "citation-type": "bibtex",
+    "citation-value": "\n\t\t\t@article {ORCID2012,\n\t\t\t\ttitle = \"ORCID: a system to uniquely identify researchers\",\n\t\t\t\tjournal = \"Learned Publishing\",\n\t\t\t\tyear = \"2022\",\n\t\t\t\tdoi = \"doi:10.1087/20140404\"\n\t\t\t\t}\n\t\t"
+  },
+  "type": "journal-article",
+  "publication-date": {
+    "year": {
+      "value": "2022"
+    },
+    "month": {
+      "value": "05"
+    },
+    "day": {
+      "value": "24"
+    }
+  },
+  "external-ids": {
+    "external-id": [
+      {
+        "external-id-type": "doi",
+        "external-id-value": "10.1187/20110402",
+        "external-id-url": {
+          "value": "https://doi.org/10.1087/20120404"
+        },
+        "external-id-relationship": "part-of"
+      },
+      {
+        "external-id-type": "doi",
+        "external-id-value": "10.1187/20110404",
+        "external-id-url": {
+          "value": "https://doi.org/10.1187/20110404"
+        },
+        "external-id-relationship": "self"
+      }
+    ]
+  },
+  "url": {
+    "value": "https://example.com"
+  },
+  "contributors": {
+    "contributor": [
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-5391-5437",
+          "path": "0000-0002-5391-5437",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Jordan"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "first",
+          "contributor-role": "author"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-4325-871X",
+          "path": "0000-0002-4325-871X",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Fran"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "author"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-4856-5225",
+          "path": "0000-0002-4856-5225",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Sam"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "assignee"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-7174-6139",
+          "path": "0000-0002-7174-6139",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Jordan"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-inventor"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-1198-7731",
+          "path": "0000-0002-1198-7731",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Frank"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-5878-5299",
+          "path": "0000-0002-5878-5299",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Ivo Saviane"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "chair-or-translator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-1635-6776",
+          "path": "0000-0003-1635-6776",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Jessica"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "editor"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-5477-7064",
+          "path": "0000-0002-5477-7064",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Albert"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "graduate-student"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-2209-5667",
+          "path": "0000-0002-2209-5667",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Alfonso Chavera"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "principal-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-0608-6864",
+          "path": "0000-0003-0608-6864",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Alfonso"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "postdoctoral-researcher"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-2258-0128",
+          "path": "0000-0002-2258-0128",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Florina"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "support-staff"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-6925-8657",
+          "path": "0000-0001-6925-8657",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Saeed"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "support-staff"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-8590-5348",
+          "path": "0000-0002-8590-5348",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Mostafa"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "support-staff"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-5052-8343",
+          "path": "0000-0002-5052-8343",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Nichal"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "support-staff"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-9657-6578",
+          "path": "0000-0002-9657-6578",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Farhad"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "support-staff"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-9485-2885",
+          "path": "0000-0001-9485-2885",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Kiyanoosh"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "support-staff"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-4452-321X",
+          "path": "0000-0003-4452-321X",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Hamed"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "support-staff"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-7760-5014",
+          "path": "0000-0001-7760-5014",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Marzieh"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "support-staff"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-1521-6229",
+          "path": "0000-0003-1521-6229",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Behnoush"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "support-staff"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-8274-4091",
+          "path": "0000-0002-8274-4091",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Mehdi"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "support-staff"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-3714-9776",
+          "path": "0000-0003-3714-9776",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Sajjad"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "support-staff"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-0377-3984",
+          "path": "0000-0003-0377-3984",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Sima"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-3620-9319",
+          "path": "0000-0003-3620-9319",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Mehdi"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-3869-6114",
+          "path": "0000-0003-3869-6114",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Laleh"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-9110-5040",
+          "path": "0000-0001-9110-5040",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Hamid"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-0964-485X",
+          "path": "0000-0003-0964-485X",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "shahrokh"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-9299-2067",
+          "path": "0000-0001-9299-2067",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Amir"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-2404-7068",
+          "path": "0000-0003-2404-7068",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Leila"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-5748-4160",
+          "path": "0000-0002-5748-4160",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Ashkan"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-0964-2689",
+          "path": "0000-0002-0964-2689",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Mohammad"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-5488-1814",
+          "path": "0000-0002-5488-1814",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Mariska"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-5495-4502",
+          "path": "0000-0001-5495-4502",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Jelmer"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-3524-5281",
+          "path": "0000-0002-3524-5281",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Menno"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-0417-6380",
+          "path": "0000-0003-0417-6380",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Joseph"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-4790-8094",
+          "path": "0000-0003-4790-8094",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Diretnan"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-0210-6880",
+          "path": "0000-0003-0210-6880",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Nils"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-4556-315X",
+          "path": "0000-0003-4556-315X",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Jacques"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-1811-3647",
+          "path": "0000-0003-1811-3647",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Anna"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-8881-7389",
+          "path": "0000-0001-8881-7389",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Olivier"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-7442-2693",
+          "path": "0000-0001-7442-2693",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Kees"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-1800-3173",
+          "path": "0000-0003-1800-3173",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Beatrix"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-4426-8968",
+          "path": "0000-0003-4426-8968",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Mahdi"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-0771-3009",
+          "path": "0000-0002-0771-3009",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Monique"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-2897-5470",
+          "path": "0000-0002-2897-5470",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Gyang"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-8635-8369",
+          "path": "0000-0001-8635-8369",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Sandra"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-9486-5050",
+          "path": "0000-0002-9486-5050",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Nathalie"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-1596-9370",
+          "path": "0000-0002-1596-9370",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Adrian"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-1376-6449",
+          "path": "0000-0002-1376-6449",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Freek"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-5504-4559",
+          "path": "0000-0002-5504-4559",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Sander"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-6225-4047",
+          "path": "0000-0001-6225-4047",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Christopher"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-9534-2668",
+          "path": "0000-0001-9534-2668",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Amalia"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      }
+    ]
+  },
+  "language-code": "en",
+  "country": {
+    "value": "CA"
+  }
+}

--- a/src/main/resources/record_3.0/samples/write_samples/work-full-3.0.json
+++ b/src/main/resources/record_3.0/samples/write_samples/work-full-3.0.json
@@ -1,0 +1,96 @@
+{
+  "title": {
+    "title": {
+      "value": "Work Title"
+    },
+    "subtitle": {
+      "value": "Work subtitle"
+    },
+    "translated-title": {
+      "value": "Translated-title English",
+      "language-code": "en"
+    }
+  },
+  "journal-title": {
+    "value": "Journal title"
+  },
+  "short-description": "This is a short description of the work.",
+  "citation": {
+    "citation-type": "bibtex",
+    "citation-value": "\n\t\t\t@article {ORCID2012,\n\t\t\t\ttitle = \"ORCID: a system to uniquely identify researchers\",\n\t\t\t\tjournal = \"Learned Publishing\",\n\t\t\t\tyear = \"2022\",\n\t\t\t\tdoi = \"doi:10.1087/20140404\"\n\t\t\t\t}\n\t\t"
+  },
+  "type": "journal-article",
+  "publication-date": {
+    "year": {
+      "value": "2022"
+    },
+    "month": {
+      "value": "05"
+    },
+    "day": {
+      "value": "24"
+    }
+  },
+  "external-ids": {
+    "external-id": [
+      {
+        "external-id-type": "doi",
+        "external-id-value": "10.1187/20120402",
+
+        "external-id-url": {
+          "value": "https://doi.org/10.1087/20120404"
+        },
+        "external-id-relationship": "part-of"
+      },
+      {
+        "external-id-type": "doi",
+        "external-id-value": "work:doi",
+        "external-id-url": {
+          "value": "http://orcid.org"
+        },
+        "external-id-relationship": "self"
+      }
+    ]
+  },
+  "url": {
+    "value": "https://example.com"
+  },
+  "contributors": {
+    "contributor": [
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-5391-5437",
+          "path": "0000-0002-5391-5437",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Jordan"
+        },
+        "contributor-email": "example@example.com",
+        "contributor-attributes": {
+          "contributor-sequence": "first",
+          "contributor-role": "author"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-4325-871X",
+          "path": "0000-0002-4325-871X",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Fran"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "author"
+        }
+      }
+    ]
+  },
+  "language-code": "en",
+  "country": {
+    "value": "CA"
+  }
+}

--- a/src/main/resources/record_3.0/samples/write_samples/work-with-NISO-roles-51-contributors-3.0.json
+++ b/src/main/resources/record_3.0/samples/write_samples/work-with-NISO-roles-51-contributors-3.0.json
@@ -1,0 +1,831 @@
+{
+  "title": {
+    "title": {
+      "value": "Work title"
+    },
+    "subtitle": {
+      "value": "Work subtitle"
+    },
+    "translated-title": {
+      "value": "Translated-title English",
+      "language-code": "en"
+    }
+  },
+  "journal-title": {
+    "value": "Journal title"
+  },
+  "short-description": "This is a short description of the work.",
+  "citation": {
+    "citation-type": "bibtex",
+    "citation-value": "\n\t\t\t@article {ORCID2012,\n\t\t\t\ttitle = \"ORCID: a system to uniquely identify researchers\",\n\t\t\t\tjournal = \"Learned Publishing\",\n\t\t\t\tyear = \"2022\",\n\t\t\t\tdoi = \"doi:10.1087/20140404\"\n\t\t\t\t}\n\t\t"
+  },
+  "type": "journal-article",
+  "publication-date": {
+    "year": {
+      "value": "2022"
+    },
+    "month": {
+      "value": "05"
+    },
+    "day": {
+      "value": "24"
+    }
+  },
+  "external-ids": {
+    "external-id": [
+      {
+        "external-id-type": "doi",
+        "external-id-value": "10.1187/20110402",
+        "external-id-url": {
+          "value": "https://doi.org/10.1087/20120404"
+        },
+        "external-id-relationship": "part-of"
+      },
+      {
+        "external-id-type": "doi",
+        "external-id-value": "10.1187/20110404",
+        "external-id-normalized-error": null,
+        "external-id-url": {
+          "value": "https://doi.org/10.1187/20110404"
+        },
+        "external-id-relationship": "self"
+      }
+    ]
+  },
+  "url": {
+    "value": "https://example.com"
+  },
+  "contributors": {
+    "contributor": [
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-5391-5437",
+          "path": "0000-0002-5391-5437",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Jordan"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "first",
+          "contributor-role": "http://credit.niso.org/contributor-roles/writing-review-editing/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-4325-871X",
+          "path": "0000-0002-4325-871X",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Fran"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "http://credit.niso.org/contributor-roles/writing-original-draft/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-4856-5225",
+          "path": "0000-0002-4856-5225",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Sam"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "http://credit.niso.org/contributor-roles/visualization/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-7174-6139",
+          "path": "0000-0002-7174-6139",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Jordan"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "http://credit.niso.org/contributor-roles/validation/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-1198-7731",
+          "path": "0000-0002-1198-7731",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Frank"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "http://credit.niso.org/contributor-roles/supervision/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-5878-5299",
+          "path": "0000-0002-5878-5299",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Ivo Saviane"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "http://credit.niso.org/contributor-roles/software/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-1635-6776",
+          "path": "0000-0003-1635-6776",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Jessica"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "http://credit.niso.org/contributor-roles/resources/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-5477-7064",
+          "path": "0000-0002-5477-7064",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Albert"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "http://credit.niso.org/contributor-roles/project-administration/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-2209-5667",
+          "path": "0000-0002-2209-5667",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Alfonso Chavera"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "http://credit.niso.org/contributor-roles/methodology/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-0608-6864",
+          "path": "0000-0003-0608-6864",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Alfonso"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "http://credit.niso.org/contributor-roles/investigation/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-2258-0128",
+          "path": "0000-0002-2258-0128",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Florina"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "http://credit.niso.org/contributor-roles/funding-acquisition/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-6925-8657",
+          "path": "0000-0001-6925-8657",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Saeed"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "http://credit.niso.org/contributor-roles/formal-analysis/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-8590-5348",
+          "path": "0000-0002-8590-5348",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Mostafa"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "http://credit.niso.org/contributor-roles/data-curation/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-5052-8343",
+          "path": "0000-0002-5052-8343",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Nichal"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "http://credit.niso.org/contributor-roles/conceptualization/"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-9657-6578",
+          "path": "0000-0002-9657-6578",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Farhad"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "support-staff"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-9485-2885",
+          "path": "0000-0001-9485-2885",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Kiyanoosh"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "support-staff"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-4452-321X",
+          "path": "0000-0003-4452-321X",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Hamed"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "support-staff"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-7760-5014",
+          "path": "0000-0001-7760-5014",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Marzieh"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "support-staff"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-1521-6229",
+          "path": "0000-0003-1521-6229",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Behnoush"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "support-staff"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-8274-4091",
+          "path": "0000-0002-8274-4091",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Mehdi"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "support-staff"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-3714-9776",
+          "path": "0000-0003-3714-9776",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Sajjad"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "support-staff"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-0377-3984",
+          "path": "0000-0003-0377-3984",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Sima"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-3620-9319",
+          "path": "0000-0003-3620-9319",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Mehdi"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-3869-6114",
+          "path": "0000-0003-3869-6114",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Laleh"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-9110-5040",
+          "path": "0000-0001-9110-5040",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Hamid"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-0964-485X",
+          "path": "0000-0003-0964-485X",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "shahrokh"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-9299-2067",
+          "path": "0000-0001-9299-2067",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Amir"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-2404-7068",
+          "path": "0000-0003-2404-7068",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Leila"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-5748-4160",
+          "path": "0000-0002-5748-4160",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Ashkan"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-0964-2689",
+          "path": "0000-0002-0964-2689",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Mohammad"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-5488-1814",
+          "path": "0000-0002-5488-1814",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Mariska"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-5495-4502",
+          "path": "0000-0001-5495-4502",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Jelmer"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-3524-5281",
+          "path": "0000-0002-3524-5281",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Menno"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-0417-6380",
+          "path": "0000-0003-0417-6380",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Joseph"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-4790-8094",
+          "path": "0000-0003-4790-8094",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Diretnan"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-0210-6880",
+          "path": "0000-0003-0210-6880",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Nils"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-4556-315X",
+          "path": "0000-0003-4556-315X",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Jacques"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-1811-3647",
+          "path": "0000-0003-1811-3647",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Anna"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-8881-7389",
+          "path": "0000-0001-8881-7389",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Olivier"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-7442-2693",
+          "path": "0000-0001-7442-2693",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Kees"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-1800-3173",
+          "path": "0000-0003-1800-3173",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Beatrix"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0003-4426-8968",
+          "path": "0000-0003-4426-8968",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Mahdi"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-0771-3009",
+          "path": "0000-0002-0771-3009",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Monique"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-2897-5470",
+          "path": "0000-0002-2897-5470",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Gyang"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-8635-8369",
+          "path": "0000-0001-8635-8369",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Sandra"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-9486-5050",
+          "path": "0000-0002-9486-5050",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Nathalie"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-1596-9370",
+          "path": "0000-0002-1596-9370",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Adrian"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-1376-6449",
+          "path": "0000-0002-1376-6449",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Freek"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0002-5504-4559",
+          "path": "0000-0002-5504-4559",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Sander"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-6225-4047",
+          "path": "0000-0001-6225-4047",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Christopher"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      },
+      {
+        "contributor-orcid": {
+          "uri": "https://orcid.org/0000-0001-9534-2668",
+          "path": "0000-0001-9534-2668",
+          "host": "orcid.org"
+        },
+        "credit-name": {
+          "value": "Amalia"
+        },
+        "contributor-email": null,
+        "contributor-attributes": {
+          "contributor-sequence": "additional",
+          "contributor-role": "co-investigator"
+        }
+      }
+    ]
+  },
+  "language-code": "en",
+  "country": {
+    "value": "CA"
+  }
+}


### PR DESCRIPTION
Adding JSON write samples to the existing record 3.0 write samples. The following samples have been added:

- address-3.0.json
- bulk-works-100-works-3.0.json
- bulk-works-3-works-3.0.json
- distinction-3.0.json
- education-3.0.json
- employment-3.0.json
- external-identifier-3.0.json
- funding-3.0-simple.json
- funding-3.0-with-NISO-roles.json
- invited-position-3.0.json
- keywords-3.0.json
- membership-3.0.json
- other-names-3.0.json
- peer-review-full-3.0-award-subject-type.json
- peer-review-full-3.0-research-resource.json
- peer-review-full-3.0.json
- peer-review-group-id.json
- peer-review-simple-3.0.json
- qualification-3.0.json
- research-resource-3.0.json
- researcher-url-3.0.json
- researcher-url-no-name-3.0.json
- service-3.0.json
- work-51-contributors-3.0.json
- work-full-3.0.json
- work-with-NISO-roles-51-contributors-3.0.json