### PR TITLE
Update WorkType.java to add ontology work type

### DIFF
--- a/src/main/java/org/orcid/jaxb/model/common/WorkType.java
+++ b/src/main/java/org/orcid/jaxb/model/common/WorkType.java
@@ -28,6 +28,7 @@ public enum WorkType implements Serializable {
     NEWSLETTER_ARTICLE("newsletter-article"),
     NEWSPAPER_ARTICLE("newspaper-article"),
     ONLINE_RESOURCE("online-resource"),
+    ONTOLOGY("ontology"),
     OTHER("other"),
     PATENT("patent"),
     PHYSICAL_OBJECT("physical-object"),


### PR DESCRIPTION
Suggestion: Add ontology as a work type. I think it is sufficiently different from data-set. We could also consider adding 'Vocabulary' or 'FAIR Enabling Resource' but 'ontology' would be a good start. Happy to discuss further!