### PR TITLE
Removed 'commons-lang' dependency that is not maintained

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,12 +173,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-lang3</artifactId>
-			<version>3.2</version>
-		</dependency>
-		<dependency>
-			<groupId>commons-lang</groupId>
-			<artifactId>commons-lang</artifactId>
-			<version>2.6</version>
+			<version>3.18.0</version>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.jaxrs</groupId>
@@ -199,7 +194,7 @@
 		<dependency>
 			<groupId>commons-io</groupId>
 			<artifactId>commons-io</artifactId>
-			<version>2.8.0</version>
+			<version>2.19.0</version>
 		</dependency>
 		
 	    <!-- javax.xml -->

--- a/src/main/java/org/orcid/jaxb/model/common_v2/Amount.java
+++ b/src/main/java/org/orcid/jaxb/model/common_v2/Amount.java
@@ -9,7 +9,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlValue;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/org/orcid/jaxb/model/common_v2/Day.java
+++ b/src/main/java/org/orcid/jaxb/model/common_v2/Day.java
@@ -13,7 +13,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlValue;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/org/orcid/jaxb/model/common_v2/FuzzyDate.java
+++ b/src/main/java/org/orcid/jaxb/model/common_v2/FuzzyDate.java
@@ -15,7 +15,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/org/orcid/jaxb/model/common_v2/Month.java
+++ b/src/main/java/org/orcid/jaxb/model/common_v2/Month.java
@@ -13,7 +13,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlValue;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/org/orcid/jaxb/model/common_v2/TranslatedTitle.java
+++ b/src/main/java/org/orcid/jaxb/model/common_v2/TranslatedTitle.java
@@ -9,7 +9,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlValue;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/org/orcid/jaxb/model/common_v2/Url.java
+++ b/src/main/java/org/orcid/jaxb/model/common_v2/Url.java
@@ -7,7 +7,7 @@
 
 package org.orcid.jaxb.model.common_v2;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/org/orcid/jaxb/model/message/Amount.java
+++ b/src/main/java/org/orcid/jaxb/model/message/Amount.java
@@ -9,7 +9,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlValue;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Java class for anonymous complex type.

--- a/src/main/java/org/orcid/jaxb/model/message/Day.java
+++ b/src/main/java/org/orcid/jaxb/model/message/Day.java
@@ -13,7 +13,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlValue;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.Serializable;
 

--- a/src/main/java/org/orcid/jaxb/model/message/Month.java
+++ b/src/main/java/org/orcid/jaxb/model/message/Month.java
@@ -13,7 +13,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlValue;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import java.io.Serializable;
 

--- a/src/main/java/org/orcid/jaxb/model/message/OrcidProfile.java
+++ b/src/main/java/org/orcid/jaxb/model/message/OrcidProfile.java
@@ -12,7 +12,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.orcid.jaxb.model.clientgroup.ClientType;
 import org.orcid.jaxb.model.clientgroup.MemberType;
 import org.orcid.model.utils.ReleaseNameUtils;

--- a/src/main/java/org/orcid/jaxb/model/message/ResearcherUrl.java
+++ b/src/main/java/org/orcid/jaxb/model/message/ResearcherUrl.java
@@ -14,7 +14,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 

--- a/src/main/java/org/orcid/jaxb/model/message/TranslatedTitle.java
+++ b/src/main/java/org/orcid/jaxb/model/message/TranslatedTitle.java
@@ -9,7 +9,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlValue;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * Java class for anonymous complex type.

--- a/src/main/java/org/orcid/jaxb/model/message/Url.java
+++ b/src/main/java/org/orcid/jaxb/model/message/Url.java
@@ -7,7 +7,7 @@
 
 package org.orcid.jaxb.model.message;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;

--- a/src/main/java/org/orcid/jaxb/model/v3/release/common/Amount.java
+++ b/src/main/java/org/orcid/jaxb/model/v3/release/common/Amount.java
@@ -11,7 +11,7 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlValue;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.orcid.jaxb.model.common.adapters.CurrencyAdapter;
 
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/src/main/java/org/orcid/jaxb/model/v3/release/common/Day.java
+++ b/src/main/java/org/orcid/jaxb/model/v3/release/common/Day.java
@@ -13,7 +13,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlValue;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/org/orcid/jaxb/model/v3/release/common/FuzzyDate.java
+++ b/src/main/java/org/orcid/jaxb/model/v3/release/common/FuzzyDate.java
@@ -15,7 +15,7 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlSeeAlso;
 import javax.xml.bind.annotation.XmlType;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/org/orcid/jaxb/model/v3/release/common/Month.java
+++ b/src/main/java/org/orcid/jaxb/model/v3/release/common/Month.java
@@ -13,7 +13,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlValue;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/org/orcid/jaxb/model/v3/release/common/TranslatedTitle.java
+++ b/src/main/java/org/orcid/jaxb/model/v3/release/common/TranslatedTitle.java
@@ -10,7 +10,7 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.XmlValue;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.orcid.jaxb.model.common.LanguageCode;
 import org.orcid.jaxb.model.common.adapters.LanguageCodeAdapter;
 

--- a/src/main/java/org/orcid/jaxb/model/v3/release/common/Url.java
+++ b/src/main/java/org/orcid/jaxb/model/v3/release/common/Url.java
@@ -7,7 +7,7 @@
 
 package org.orcid.jaxb.model.v3.release.common;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/org/orcid/jaxb/model/v3/release/record/ExternalID.java
+++ b/src/main/java/org/orcid/jaxb/model/v3/release/record/ExternalID.java
@@ -10,7 +10,7 @@ import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.orcid.jaxb.model.common.Relationship;
 import org.orcid.jaxb.model.common.adapters.RelationshipAdapter;
 import org.orcid.jaxb.model.v3.release.common.TransientError;

--- a/src/main/java/org/orcid/model/utils/DateUtils.java
+++ b/src/main/java/org/orcid/model/utils/DateUtils.java
@@ -12,7 +12,7 @@ import javax.xml.datatype.DatatypeConstants;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.datatype.XMLGregorianCalendar;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 /**
  * 


### PR DESCRIPTION
Security related patch:
- Removed 'commons-lang' dependency that is not maintained.
- Updated 'commons-lang3' and 'commons-io' to versions without vulnerabilities.