### PR TITLE
PD-7614 add /orcid-internal/account-recovery scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.orcid</groupId>
 	<artifactId>orcid-model</artifactId>
-	<version>4.0.0</version>
+	<version>4.0.1</version>
 
 	<name>ORCID - Model</name>
 	<description>Container for all classes that will be used to marshal and unmarshal XML/JSON from the API</description>

--- a/src/main/java/org/orcid/jaxb/model/message/ScopeConstants.java
+++ b/src/main/java/org/orcid/jaxb/model/message/ScopeConstants.java
@@ -53,6 +53,7 @@ final public class ScopeConstants {
     // Internal API
     public static final String INTERNAL = "/orcid-internal";
     public static final String INTERNAL_PERSON_LAST_MODIFIED = "/orcid-internal/person/last_modified";
+    public static final String INTERNAL_ACCOUNT_RECOVERY = "/orcid-internal/account-recovery";
     public static final String IDENTIFIER_TYPES_CREATE = "/identifier-types/create";
     
     // Salesforce access

--- a/src/main/java/org/orcid/jaxb/model/message/ScopePathType.java
+++ b/src/main/java/org/orcid/jaxb/model/message/ScopePathType.java
@@ -128,6 +128,7 @@ public enum ScopePathType implements Serializable {
     // Internal scopes
     @XmlEnumValue(ScopeConstants.INTERNAL) INTERNAL (ScopeConstants.INTERNAL),
     @XmlEnumValue(ScopeConstants.INTERNAL_PERSON_LAST_MODIFIED) INTERNAL_PERSON_LAST_MODIFIED (ScopeConstants.INTERNAL_PERSON_LAST_MODIFIED),
+    @XmlEnumValue(ScopeConstants.INTERNAL_ACCOUNT_RECOVERY) INTERNAL_ACCOUNT_RECOVERY (ScopeConstants.INTERNAL_ACCOUNT_RECOVERY),
     
     @XmlEnumValue(ScopeConstants.IDENTIFIER_TYPES_CREATE) IDENTIFIER_TYPES_CREATE(ScopeConstants.IDENTIFIER_TYPES_CREATE),
 
@@ -302,6 +303,7 @@ public enum ScopePathType implements Serializable {
     public boolean isInternalScope() {
         switch (this) {
         case INTERNAL_PERSON_LAST_MODIFIED:
+        case INTERNAL_ACCOUNT_RECOVERY:
         case INTERNAL:
             return true;
         default:

--- a/src/test/java/org/orcid/jaxb/model/message/ScopePathTypeTest.java
+++ b/src/test/java/org/orcid/jaxb/model/message/ScopePathTypeTest.java
@@ -307,4 +307,24 @@ public class ScopePathTypeTest {
                 assertTrue(combined.contains(ScopePathType.AUTHENTICATE));
                 assertTrue(combined.contains(ScopePathType.READ_PUBLIC));
         }
+
+	@Test
+	public void test_INTERNAL_ACCOUNT_RECOVERY() {
+		// Test INTERNAL_ACCOUNT_RECOVERY: a leaf scope, it inherits nothing
+		Set<ScopePathType> combined = ScopePathType.INTERNAL_ACCOUNT_RECOVERY.combined();
+		assertEquals(1, combined.size());
+		assertTrue(combined.contains(ScopePathType.INTERNAL_ACCOUNT_RECOVERY));
+		assertTrue(ScopePathType.INTERNAL_ACCOUNT_RECOVERY.isInternalScope());
+		assertEquals(ScopePathType.INTERNAL_ACCOUNT_RECOVERY, ScopePathType.fromValue(ScopeConstants.INTERNAL_ACCOUNT_RECOVERY));
+	}
+
+	@Test
+	public void test_INTERNAL_ACCOUNT_RECOVERY_isNotImpliedByInternal() {
+		// The nested-looking path must not create inheritance in either direction:
+		// a client holding /orcid-internal must not be able to use /orcid-internal/account-recovery.
+		assertFalse(ScopePathType.INTERNAL.hasScope(ScopePathType.INTERNAL_ACCOUNT_RECOVERY));
+		assertFalse(ScopePathType.INTERNAL_ACCOUNT_RECOVERY.hasScope(ScopePathType.INTERNAL));
+		assertFalse(ScopePathType.INTERNAL_PERSON_LAST_MODIFIED.hasScope(ScopePathType.INTERNAL_ACCOUNT_RECOVERY));
+		assertFalse(ScopePathType.INTERNAL_ACCOUNT_RECOVERY.hasScope(ScopePathType.INTERNAL_PERSON_LAST_MODIFIED));
+	}
 }


### PR DESCRIPTION
Adds a dedicated internal sub-scope, `/orcid-internal/account-recovery`, for the two account-recovery endpoints being added to `orcid-internal-api` under PD-5872 (automating the lost-email account recovery workflow). This is the first of three repos in that change; ORCID-Source cannot be merged until this is released.
